### PR TITLE
Fix/show metrics without search term

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -43,6 +43,14 @@ def get_argument(name: str):
   """
   return arguments_map[name] if name in arguments_map else None
 
+def set_argument(key, value):
+  """
+  Set a new value into 'arguments_map'
+  """
+  arguments_map.update({
+    key: value
+  })
+
 if len(arguments_map) == 0:
   # process the arguments and populates the Dict arguments_map
   arguments_map = process_arguments(sys.argv[1:])

--- a/src/match_engine.py
+++ b/src/match_engine.py
@@ -184,5 +184,6 @@ def run():
     discoverer(regexTerm, path)
 
   else:
+    params.enable_quite_mode() # force quiet mode
     show_message("[RED]you need to enter a search term[ENDC]")
     show_message("[GREEN]finder by=[YELLOW]<term>[ENDC]")

--- a/src/params.py
+++ b/src/params.py
@@ -1,5 +1,5 @@
 import os
-from src.cli import get_argument
+from src.cli import get_argument, set_argument
 from src.disc_manager import add_end_slash
 from src.utils import parse_int
 
@@ -87,3 +87,9 @@ def is_quiet():
   Indicate that quiet mode is enabled
   """
   return bool(get_argument('-quiet') or get_argument('-q'))
+
+def enable_quite_mode():
+  """
+  Just enable the quiet mode
+  """
+  set_argument('-quiet', True)

--- a/tests/src/test_cli.py
+++ b/tests/src/test_cli.py
@@ -41,5 +41,15 @@ class TestCli(unittest.TestCase):
     self.assertIsNone(cli.get_argument("-test3"))
     self.assertTrue(cli.get_argument("-test1"))
 
+  def test_set_argument(self):
+    cli.arguments_map = {}
+    self.assertIsNone(cli.get_argument("-test"))
+    cli.set_argument("-test", True)
+    self.assertTrue(cli.get_argument("-test"))
+    cli.set_argument("test2", "whatever")
+    self.assertEqual("whatever", cli.get_argument("test2"))
+    cli.set_argument("test2", "whatever-test")
+    self.assertEqual("whatever-test", cli.get_argument("test2"))
+
 if __name__ == "__main__":
   unittest.main()

--- a/tests/src/test_params.py
+++ b/tests/src/test_params.py
@@ -87,6 +87,12 @@ class TestParams(unittest.TestCase):
     cli.arguments_map = {}
     self.assertFalse(params.is_quiet())
 
+  def test_enable_quiet_mode(self):
+    cli.arguments_map = {}
+    self.assertFalse(params.is_quiet())
+    params.enable_quite_mode()
+    self.assertTrue(params.is_quiet())
+
 
 if __name__ == "__main__":
   unittest.main()


### PR DESCRIPTION
- Fix show metrics when there's no search term
- Added `src.cli.set_argument` function
- Added `src.params.enable_quite_mode` function