### PR TITLE
Fix/consider only file name for fm and fdm

### DIFF
--- a/src/disc_manager.py
+++ b/src/disc_manager.py
@@ -54,3 +54,12 @@ def load_file(path: str):
   file.close()
 
   return content
+
+def get_file_name_from(path: str):
+  """
+  Extract the file name and return it
+  """
+  if type(path) != str:
+    return ""
+  chunks = path.split("/")
+  return chunks[-1]

--- a/src/match_engine.py
+++ b/src/match_engine.py
@@ -3,7 +3,7 @@ import src.params as params
 from time import time
 from src.utils import extract_extension, pattern_test
 from src.messenger import show_message, print_matches, show_mectrics, show_help
-from src.disc_manager import is_directory, is_file, get_list_dir, load_file
+from src.disc_manager import is_directory, is_file, get_list_dir, load_file, get_file_name_from
 
 METRICS = {
   "lines_matches_count": 0,
@@ -133,20 +133,21 @@ def you_shall_not_pass(current_path):
     return True
 
   if is_file(current_path):
+    file_name = get_file_name_from(current_path)
     file_extension = extract_extension(current_path)
 
     """
     Check the value of 'file-dont-match'
     If the path is not allowed, then continue the loop
     """
-    if is_file_dont_match(current_path):
+    if is_file_dont_match(file_name):
       return True
 
     """
     Check the value of 'file-match'
     If the path is not allowed, then continue the loop
     """
-    if is_file_match(current_path) == False:
+    if is_file_match(file_name) == False:
       return True
 
     """

--- a/tests/src/test_disc_manager.py
+++ b/tests/src/test_disc_manager.py
@@ -55,5 +55,15 @@ class TestDiscManager(unittest.TestCase):
     self.assertEqual([], disc_manager.load_file("/whatever.txt"))
     self.assertEqual([], disc_manager.load_file(""))
 
+  def test_get_file_name_from(self):
+    self.assertEqual("", disc_manager.get_file_name_from(False))
+    self.assertEqual("", disc_manager.get_file_name_from(True))
+    self.assertEqual("", disc_manager.get_file_name_from(None))
+    self.assertEqual("", disc_manager.get_file_name_from("/"))
+    self.assertEqual("", disc_manager.get_file_name_from(""))
+    self.assertEqual("test.txt", disc_manager.get_file_name_from("/test.txt"))
+    self.assertEqual("test.txt", disc_manager.get_file_name_from("lll/test.txt"))
+    self.assertEqual("test.txt", disc_manager.get_file_name_from("test.txt"))
+
 if __name__ == "__main__":
   unittest.main()


### PR DESCRIPTION
- Refactoring to consider only file name for `file-match` and `file-dont-match`
- Added `get_file_name_from` function